### PR TITLE
Fix Azure functions version - lower case v4 - AB#431979

### DIFF
--- a/EPR.DocumentSchemaJobRunner/EPR.DocumentSchemaJobRunner.Function/EPR.DocumentSchemaJobRunner.Function.csproj
+++ b/EPR.DocumentSchemaJobRunner/EPR.DocumentSchemaJobRunner.Function/EPR.DocumentSchemaJobRunner.Function.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
-        <AzureFunctionsVersion>V4</AzureFunctionsVersion>
+        <AzureFunctionsVersion>v4</AzureFunctionsVersion>
         <RootNamespace>EPR.DocumentSchemaJobRunner.Function</RootNamespace>
     </PropertyGroup>
     <ItemGroup>


### PR DESCRIPTION
The version in the function app .csproj file was set to

`<AzureFunctionsVersion>V4</AzureFunctionsVersion>`

When developers run this on their own machines, the functions wouldn't start. The version should have a lowercase v:

`<AzureFunctionsVersion>v4</AzureFunctionsVersion>`