### PR TITLE
SUB-273: Amendment to upgrade-to-dotnet10-logic

### DIFF
--- a/EPR.DocumentSchemaJobRunner/EPR.DocumentSchemaJobRunner.Data/DbContexts/SubmissionsDbContext.cs
+++ b/EPR.DocumentSchemaJobRunner/EPR.DocumentSchemaJobRunner.Data/DbContexts/SubmissionsDbContext.cs
@@ -41,6 +41,7 @@ public class SubmissionsDbContext : DbContext
             entity.Property(x => x.JobType).HasConversion<string>();
             entity.HasDiscriminator(x => x.JobType)
                 .HasValue<ComplianceSchemeIdJobOutput>(JobType.ComplianceSchemeId);
+            entity.HasDiscriminatorInJsonId();
         });
 
         modelBuilder.Entity<ComplianceSchemeIdJobOutput>()


### PR DESCRIPTION
Restore composed id on JobOutput discriminated hierarchy

Add HasDiscriminatorInJsonId() to the AbstractJobOutput configuration so the Cosmos id field is composed with the JobType discriminator again, matching the pre-EF-Core-10 behaviour that was lost after the .NET 10 / EF Core 10 upgrade (#26) removed the derived-type configuration block.